### PR TITLE
chore: remove console logs from prod

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,8 +1,17 @@
-module.exports = {
-  presets: ["module:metro-react-native-babel-preset"],
-  plugins: [
-    // the relay plugin should run before other plugins or presets
-    // to ensure the graphql template literals are correctly transformed
-    "relay",
-  ],
+const presets = [
+  "module:metro-react-native-babel-preset"
+]
+
+const plugins = [
+  // the relay plugin should run before other plugins or presets
+  // to ensure the graphql template literals are correctly transformed
+  "relay",
+]
+
+if (process.env.CI) {
+  // When running a bundled app, these statements can cause a big bottleneck in the JavaScript thread.
+  // This includes calls from debugging libraries and logs we might forget to remove
+  plugins.push("transform-remove-console")
 }
+
+module.exports = { presets, plugins }

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@types/yup": "^0.29.13",
     "babel-jest": "^26.6.3",
     "babel-plugin-relay": "^12.0.0",
+    "babel-plugin-transform-remove-console": "^6.9.4",
     "concurrently": "^7.0.0",
     "eslint": "^7.14.0",
     "eslint-config-prettier": "^8.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2124,6 +2124,11 @@ babel-plugin-syntax-trailing-function-commas@^7.0.0-beta.0:
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-7.0.0-beta.0.tgz#aa213c1435e2bffeb6fca842287ef534ad05d5cf"
   integrity sha512-Xj9XuRuz3nTSbaTXWv3itLOcxyF4oPD8douBBmj7U9BBC6nEBYfyOJYQMf/8PJAFotC62UY5dFfIGEPr7WswzQ==
 
+babel-plugin-transform-remove-console@^6.9.4:
+  version "6.9.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-remove-console/-/babel-plugin-transform-remove-console-6.9.4.tgz#b980360c067384e24b357a588d807d3c83527780"
+  integrity sha1-uYA2DAZzhOJLNXpYjYB9PINSd4A=
+
 babel-preset-current-node-syntax@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.0.1.tgz#b4399239b89b2a011f9ddbe3e4f401fc40cff73b"


### PR DESCRIPTION
The goal of this PR is to adhere to the react-native performance guidelines and remove the `console.log`s from production builds. These statements can cause a big bottleneck in the JavaScript thread and they can come from our own code or from any of the packages we are using. If we would like to have something logged to be used as a breadcrumb, we will need to use a different tool that maybe runs natively to avoid adding charge to the JS thread. Maybe `addBreadcrumb` from `Sentry` 🤷‍♂️

See https://reactnative.dev/docs/performance#using-consolelog-statements